### PR TITLE
Add manual rotation update button

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -9,10 +9,6 @@ export default async function AdminPage() {
   const weekStart = new Date();
   weekStart.setHours(0, 0, 0, 0);
   weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7));
-  const week = await prisma.week.findUnique({
-    where: { startDate: weekStart },
-    include: { assignments: true },
-  });
 
   async function addMember(formData: FormData) {
     "use server";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Link from "next/link";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -31,8 +32,12 @@ export default function RootLayout({
           <aside className="w-56 bg-neutral-950 border-r border-neutral-800 flex flex-col p-6 gap-4 shadow-sm">
             <h1 className="text-xl font-bold mb-6 text-neutral-300">お掃除当番管理</h1>
             <nav className="flex flex-col gap-2">
-              <a href="/" className="hover:underline text-cyan-400">トップページ</a>
-              <a href="/admin" className="hover:underline text-cyan-400">管理画面</a>
+              <Link href="/" className="hover:underline text-cyan-400">
+                トップページ
+              </Link>
+              <Link href="/admin" className="hover:underline text-cyan-400">
+                管理画面
+              </Link>
             </nav>
           </aside>
           <main className="flex-1 p-8 bg-neutral-900 text-neutral-100 min-h-screen flex flex-col items-center justify-center">{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import { prisma } from "../lib/prisma";
+import { rotateThisWeekFromLastWeek } from "../lib/rotation";
+import { revalidatePath } from "next/cache";
 import { format } from "date-fns";
 
 async function autoRotateIfNeeded(weekStart: Date) {
@@ -63,6 +65,12 @@ async function autoRotateIfNeeded(weekStart: Date) {
     });
   }
 }
+
+async function updateRotation() {
+  "use server";
+  await rotateThisWeekFromLastWeek();
+  revalidatePath("/");
+}
 export default async function Home() {
   // 今週の開始日を算出（例：月曜始まり）
   const now = new Date();
@@ -102,6 +110,14 @@ export default async function Home() {
       <div className="mb-2 text-gray-500">
         週の開始日: {format(weekStart, "yyyy年MM月dd日")}
       </div>
+      <form action={updateRotation} className="mb-4">
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-1 rounded"
+        >
+          ローテーション更新
+        </button>
+      </form>
       {members.length === 0 ? (
         <div className="text-red-500">ユーザーが登録されていません。</div>
       ) : (

--- a/src/lib/rotation.ts
+++ b/src/lib/rotation.ts
@@ -35,3 +35,71 @@ export async function regenerateThisWeekAssignments() {
     });
   }
 }
+
+export async function rotateThisWeekFromLastWeek() {
+  // 今週の開始日を計算
+  const now = new Date();
+  const weekStart = new Date(now);
+  weekStart.setHours(0, 0, 0, 0);
+  weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7));
+
+  // 前週の開始日を取得
+  const prevWeekStart = new Date(weekStart);
+  prevWeekStart.setDate(prevWeekStart.getDate() - 7);
+
+  // 前週の割り当て取得
+  const prevWeek = await prisma.week.findUnique({
+    where: { startDate: prevWeekStart },
+    include: {
+      assignments: {
+        include: { member: true },
+        orderBy: { placeId: "asc" },
+      },
+    },
+  });
+
+  // 担当者・場所リスト取得
+  const members = await prisma.member.findMany({ orderBy: { id: "asc" } });
+  const places = await prisma.place.findMany({ orderBy: { id: "asc" } });
+
+  // 今週のWeekレコード作成
+  const week = await prisma.week.upsert({
+    where: { startDate: weekStart },
+    update: {},
+    create: { startDate: weekStart },
+  });
+
+  // 既存の割り当てを削除
+  await prisma.dutyAssignment.deleteMany({ where: { weekId: week.id } });
+
+  // 前週がなければID順で割り当て
+  if (!prevWeek || prevWeek.assignments.length === 0) {
+    for (let i = 0; i < places.length; i++) {
+      await prisma.dutyAssignment.create({
+        data: {
+          weekId: week.id,
+          placeId: places[i].id,
+          memberId: members[i % members.length].id,
+        },
+      });
+    }
+    return;
+  }
+
+  // 前週の担当者リストを一つずらす
+  const prevMembers = prevWeek.assignments.map((a) => a.member);
+  const rotated = [
+    prevMembers[prevMembers.length - 1],
+    ...prevMembers.slice(0, -1),
+  ];
+
+  for (let i = 0; i < places.length; i++) {
+    await prisma.dutyAssignment.create({
+      data: {
+        weekId: week.id,
+        placeId: places[i].id,
+        memberId: rotated[i % rotated.length].id,
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary of changes
- implement manual rotation generator in `rotation.ts`
- add button on home page to trigger manual rotation
- adjust layout navigation to use `Link`
- clean unused variable in admin page

## Related issue numbers
- N/A

## How to test or reproduce
1. Install dependencies with `npm install`
2. Set `DATABASE_URL` to your SQLite file
3. Run `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853b5bcf5c08327a566ba5738337056