### PR TITLE
Refactor to follow Next.js best practices

### DIFF
--- a/src/app/actions/rotation.ts
+++ b/src/app/actions/rotation.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import { advanceCurrentWeekRotation } from "@/lib/rotation";
+import { revalidatePath } from "next/cache";
+
+export async function updateRotation() {
+  await advanceCurrentWeekRotation();
+  revalidatePath("/");
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,14 +1,12 @@
-import { prisma } from "../../lib/prisma";
+import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
-import { regenerateThisWeekAssignments } from '@/lib/rotation'
+import { regenerateThisWeekAssignments } from "@/lib/rotation";
 import { ConfirmDeleteButton } from "./components/ConfirmDeleteButton";
+import { getWeekStart } from "@/lib/week";
 
 export default async function AdminPage() {
   const members = await prisma.member.findMany();
   const places = await prisma.place.findMany();
-  const weekStart = new Date();
-  weekStart.setHours(0, 0, 0, 0);
-  weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7));
 
   async function addMember(formData: FormData) {
     "use server";
@@ -36,15 +34,13 @@ export default async function AdminPage() {
     if (!id) return;
 
     // サーバーアクション内で再取得
-    const weekStart = new Date();
-    weekStart.setHours(0, 0, 0, 0);
-    weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7));
+    const weekStart = getWeekStart();
     const week = await prisma.week.findUnique({
       where: { startDate: weekStart },
       include: { assignments: true },
     });
 
-    const assigned = week?.assignments.some(a => a.memberId === id);
+    const assigned = week?.assignments.some((a) => a.memberId === id);
     await prisma.member.delete({ where: { id } });
     if (assigned) {
       await regenerateThisWeekAssignments();
@@ -58,15 +54,13 @@ export default async function AdminPage() {
     if (!id) return;
 
     // サーバーアクション内で再取得
-    const weekStart = new Date();
-    weekStart.setHours(0, 0, 0, 0);
-    weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7));
+    const weekStart = getWeekStart();
     const week = await prisma.week.findUnique({
       where: { startDate: weekStart },
       include: { assignments: true },
     });
 
-    const assigned = week?.assignments.some(a => a.placeId === id);
+    const assigned = week?.assignments.some((a) => a.placeId === id);
     await prisma.place.delete({ where: { id } });
     if (assigned) {
       await regenerateThisWeekAssignments();
@@ -81,8 +75,18 @@ export default async function AdminPage() {
       <section className="mb-10">
         <h2 className="text-lg font-semibold mb-2">ユーザー登録</h2>
         <form action={addMember} className="flex gap-2 mb-4">
-          <input name="memberName" className="border px-2 py-1 rounded" placeholder="名前" required />
-          <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">追加</button>
+          <input
+            name="memberName"
+            className="border px-2 py-1 rounded"
+            placeholder="名前"
+            required
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white px-4 py-1 rounded"
+          >
+            追加
+          </button>
         </form>
         <ul className="list-disc pl-5">
           {members.map((m) => (
@@ -90,7 +94,10 @@ export default async function AdminPage() {
               {m.name}
               <form action={deleteMember}>
                 <input type="hidden" name="memberId" value={m.id} />
-                <ConfirmDeleteButton type="submit" className="ml-2 text-red-400 hover:text-red-600">
+                <ConfirmDeleteButton
+                  type="submit"
+                  className="ml-2 text-red-400 hover:text-red-600"
+                >
                   削除
                 </ConfirmDeleteButton>
               </form>
@@ -102,8 +109,18 @@ export default async function AdminPage() {
       <section>
         <h2 className="text-lg font-semibold mb-2">掃除場所登録</h2>
         <form action={addPlace} className="flex gap-2 mb-4">
-          <input name="placeName" className="border px-2 py-1 rounded" placeholder="場所名" required />
-          <button type="submit" className="bg-green-500 text-white px-4 py-1 rounded">追加</button>
+          <input
+            name="placeName"
+            className="border px-2 py-1 rounded"
+            placeholder="場所名"
+            required
+          />
+          <button
+            type="submit"
+            className="bg-green-500 text-white px-4 py-1 rounded"
+          >
+            追加
+          </button>
         </form>
         <ul className="list-disc pl-5">
           {places.map((p) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,82 +1,13 @@
-import { prisma } from "../lib/prisma";
-import { advanceCurrentWeekRotation } from "../lib/rotation";
-import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { autoRotateIfNeeded } from "@/lib/rotation";
+import { getWeekStart } from "@/lib/week";
+import { updateRotation } from "./actions/rotation";
 import { format } from "date-fns";
 
-async function autoRotateIfNeeded(weekStart: Date) {
-  // 今週の割り当てが既にあれば何もしない
-  const week = await prisma.week.findUnique({
-    where: { startDate: weekStart },
-    include: { assignments: true },
-  });
-  if (week && week.assignments.length > 0) return;
-
-  // 前週の開始日
-  const prevWeekStart = new Date(weekStart);
-  prevWeekStart.setDate(prevWeekStart.getDate() - 7);
-
-  // 前週の割り当て取得
-  const prevWeek = await prisma.week.findUnique({
-    where: { startDate: prevWeekStart },
-    include: {
-      assignments: {
-        include: { place: true, member: true },
-        orderBy: { placeId: "asc" },
-      },
-    },
-  });
-
-  // 担当者・場所リスト取得
-  const members = await prisma.member.findMany({ orderBy: { id: "asc" } });
-  const places = await prisma.place.findMany({ orderBy: { id: "asc" } });
-
-  // 今週のWeekレコード作成
-  const newWeek = await prisma.week.upsert({
-    where: { startDate: weekStart },
-    update: {},
-    create: { startDate: weekStart },
-  });
-
-  // 前週がなければ初期割り当て（ID順で割り当て）
-  if (!prevWeek || prevWeek.assignments.length === 0) {
-    for (let i = 0; i < places.length; i++) {
-      await prisma.dutyAssignment.create({
-        data: {
-          weekId: newWeek.id,
-          placeId: places[i].id,
-          memberId: members[i % members.length].id,
-        },
-      });
-    }
-    return;
-  }
-
-  // ローテーション: 前週の担当者リストを一つずらす
-  const prevMembers = prevWeek.assignments.map(a => a.member);
-  const rotated = [prevMembers[prevMembers.length - 1], ...prevMembers.slice(0, -1)];
-
-  for (let i = 0; i < places.length; i++) {
-    await prisma.dutyAssignment.create({
-      data: {
-        weekId: newWeek.id,
-        placeId: places[i].id,
-        memberId: rotated[i % rotated.length].id,
-      },
-    });
-  }
-}
-
-async function updateRotation() {
-  "use server";
-  await advanceCurrentWeekRotation();
-  revalidatePath("/");
-}
 export default async function Home() {
   // 今週の開始日を算出（例：月曜始まり）
   const now = new Date();
-  const weekStart = new Date(now);
-  weekStart.setHours(0, 0, 0, 0);
-  weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7));
+  const weekStart = getWeekStart(now);
   await autoRotateIfNeeded(weekStart);
 
   // 今週のWeekレコード取得
@@ -131,8 +62,12 @@ export default async function Home() {
           <tbody>
             {assignmentsByMember.map(({ member, place }) => (
               <tr key={member.id} className="even:bg-neutral-800">
-                <td className="py-2 px-4 border-b border-neutral-700">{member.name}</td>
-                <td className="py-2 px-4 border-b border-neutral-700">{place}</td>
+                <td className="py-2 px-4 border-b border-neutral-700">
+                  {member.name}
+                </td>
+                <td className="py-2 px-4 border-b border-neutral-700">
+                  {place}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -1,0 +1,6 @@
+export function getWeekStart(date: Date = new Date()): Date {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - ((start.getDay() + 6) % 7));
+  return start;
+}


### PR DESCRIPTION
## Summary
- create `getWeekStart` helper to centralize week calculations
- add server action `updateRotation`
- refactor pages to use new helper and action
- use `@/` imports instead of relative paths

## Related Issues
- None

## Testing
- `npm run build`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853d66e08348327a6651c6eee690588