### PR TITLE
Add reusable button component with hover styles

### DIFF
--- a/src/app/admin/components/ConfirmDeleteButton.tsx
+++ b/src/app/admin/components/ConfirmDeleteButton.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import React from 'react';
+import { Button } from '@/components/Button';
 
 export function ConfirmDeleteButton({ children, ...props }: React.ComponentProps<'button'>) {
   return (
-    <button
+    <Button
+      variant="danger"
       {...props}
       onClick={e => {
         if (!confirm('本当に削除しますか？')) {
@@ -13,6 +15,6 @@ export function ConfirmDeleteButton({ children, ...props }: React.ComponentProps
       }}
     >
       {children}
-    </button>
+    </Button>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache";
 import { regenerateThisWeekAssignments } from "@/lib/rotation";
 import { ConfirmDeleteButton } from "./components/ConfirmDeleteButton";
 import { getWeekStart } from "@/lib/week";
+import { Button } from "@/components/Button";
 
 export default async function AdminPage() {
   const members = await prisma.member.findMany();
@@ -81,12 +82,7 @@ export default async function AdminPage() {
             placeholder="名前"
             required
           />
-          <button
-            type="submit"
-            className="bg-blue-500 text-white px-4 py-1 rounded"
-          >
-            追加
-          </button>
+          <Button type="submit">追加</Button>
         </form>
         <ul className="list-disc pl-5">
           {members.map((m) => (
@@ -94,10 +90,7 @@ export default async function AdminPage() {
               {m.name}
               <form action={deleteMember}>
                 <input type="hidden" name="memberId" value={m.id} />
-                <ConfirmDeleteButton
-                  type="submit"
-                  className="ml-2 text-red-400 hover:text-red-600"
-                >
+                <ConfirmDeleteButton type="submit" className="ml-2">
                   削除
                 </ConfirmDeleteButton>
               </form>
@@ -115,12 +108,9 @@ export default async function AdminPage() {
             placeholder="場所名"
             required
           />
-          <button
-            type="submit"
-            className="bg-green-500 text-white px-4 py-1 rounded"
-          >
+          <Button variant="success" type="submit">
             追加
-          </button>
+          </Button>
         </form>
         <ul className="list-disc pl-5">
           {places.map((p) => (
@@ -128,10 +118,7 @@ export default async function AdminPage() {
               {p.name}
               <form action={deletePlace}>
                 <input type="hidden" name="placeId" value={p.id} />
-                <ConfirmDeleteButton
-                  type="submit"
-                  className="ml-2 text-red-400 hover:text-red-600"
-                >
+                <ConfirmDeleteButton type="submit" className="ml-2">
                   削除
                 </ConfirmDeleteButton>
               </form>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { autoRotateIfNeeded } from "@/lib/rotation";
 import { getWeekStart } from "@/lib/week";
 import { updateRotation } from "./actions/rotation";
+import { Button } from "@/components/Button";
 import { format } from "date-fns";
 
 export default async function Home() {
@@ -42,12 +43,7 @@ export default async function Home() {
         週の開始日: {format(weekStart, "yyyy年MM月dd日")}
       </div>
       <form action={updateRotation} className="mb-4">
-        <button
-          type="submit"
-          className="bg-blue-600 text-white px-4 py-1 rounded"
-        >
-          ローテーション更新
-        </button>
+        <Button type="submit">ローテーション更新</Button>
       </form>
       {members.length === 0 ? (
         <div className="text-red-500">ユーザーが登録されていません。</div>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,28 @@
+'use client';
+import React from 'react';
+
+export type ButtonVariant = 'primary' | 'success' | 'danger';
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: 'bg-blue-600 hover:bg-blue-700',
+  success: 'bg-green-600 hover:bg-green-700',
+  danger: 'bg-red-600 hover:bg-red-700',
+};
+
+export interface ButtonProps extends React.ComponentProps<'button'> {
+  variant?: ButtonVariant;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button({ variant = 'primary', className = '', ...props }, ref) {
+    const base = 'text-white px-4 py-1 rounded';
+    const variantClass = variantClasses[variant];
+    return (
+      <button
+        ref={ref}
+        className={`${base} ${variantClass} ${className}`}
+        {...props}
+      />
+    );
+  }
+);

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { Button } from '../Button';
+import { vi, expect, test, afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+
+test('applies variant classes', () => {
+  const { getByText } = render(<Button variant="success">OK</Button>);
+  const btn = getByText('OK');
+  expect(btn.className).toContain('bg-green-600');
+  expect(btn.className).toContain('hover:bg-green-700');
+});
+
+test('handles click event', () => {
+  const onClick = vi.fn();
+  const { getByText } = render(<Button onClick={onClick}>Click</Button>);
+  fireEvent.click(getByText('Click'));
+  expect(onClick).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary of changes
- introduce `Button` component with color variants
- apply new component across pages and confirm delete button
- add tests for button component

## Related issues
- N/A

## How to test
- `npm install`
- `npm run lint`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6853fa34a0f483278a1025449879bbfc