### PR TITLE
Add spinner during server actions

### DIFF
--- a/src/app/admin/components/ConfirmDeleteButton.tsx
+++ b/src/app/admin/components/ConfirmDeleteButton.tsx
@@ -1,19 +1,24 @@
 'use client';
 
 import React from 'react';
+import { useFormStatus } from 'react-dom';
 import { Button } from '@/components/Button';
+import { Spinner } from '@/components/Spinner';
 
 export function ConfirmDeleteButton({ children, ...props }: React.ComponentProps<'button'>) {
+  const { pending } = useFormStatus();
   return (
     <Button
       variant="danger"
       {...props}
-      onClick={e => {
+      disabled={pending}
+      onClick={(e) => {
         if (!confirm('本当に削除しますか？')) {
           e.preventDefault();
         }
       }}
     >
+      {pending && <Spinner />}
       {children}
     </Button>
   );

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,7 +3,7 @@ import { revalidatePath } from "next/cache";
 import { regenerateThisWeekAssignments } from "@/lib/rotation";
 import { ConfirmDeleteButton } from "./components/ConfirmDeleteButton";
 import { getWeekStart } from "@/lib/week";
-import { Button } from "@/components/Button";
+import { SubmitButton } from "@/components/SubmitButton";
 
 export default async function AdminPage() {
   const members = await prisma.member.findMany();
@@ -82,7 +82,7 @@ export default async function AdminPage() {
             placeholder="名前"
             required
           />
-          <Button type="submit">追加</Button>
+          <SubmitButton type="submit">追加</SubmitButton>
         </form>
         <ul className="divide-y divide-neutral-700 border border-neutral-700 rounded-md">
           {members.map((m) => (
@@ -106,9 +106,9 @@ export default async function AdminPage() {
             placeholder="場所名"
             required
           />
-          <Button variant="success" type="submit">
+          <SubmitButton variant="success" type="submit">
             追加
-          </Button>
+          </SubmitButton>
         </form>
         <ul className="divide-y divide-neutral-700 border border-neutral-700 rounded-md">
           {places.map((p) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { autoRotateIfNeeded } from "@/lib/rotation";
 import { getWeekStart } from "@/lib/week";
 import { updateRotation } from "./actions/rotation";
-import { Button } from "@/components/Button";
+import { SubmitButton } from "@/components/SubmitButton";
 import { format } from "date-fns";
 
 export default async function Home() {
@@ -48,7 +48,7 @@ export default async function Home() {
         週の開始日: {format(weekStart, "yyyy年MM月dd日")}
       </div>
       <form action={updateRotation} className="mb-4">
-        <Button type="submit">ローテーション更新</Button>
+        <SubmitButton type="submit">ローテーション更新</SubmitButton>
       </form>
       {members.length === 0 ? (
         <div className="text-red-500">ユーザーが登録されていません。</div>

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,27 @@
+'use client'
+import React from 'react'
+
+export function Spinner({ className = 'h-4 w-4 mr-2 text-white' }: { className?: string }) {
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      ></path>
+    </svg>
+  )
+}

--- a/src/components/SubmitButton.tsx
+++ b/src/components/SubmitButton.tsx
@@ -1,0 +1,15 @@
+'use client'
+import React from 'react'
+import { useFormStatus } from 'react-dom'
+import { Button, ButtonProps } from './Button'
+import { Spinner } from './Spinner'
+
+export function SubmitButton({ children, disabled, ...props }: ButtonProps) {
+  const { pending } = useFormStatus()
+  return (
+    <Button {...props} disabled={pending || disabled}>
+      {pending && <Spinner />}
+      {children}
+    </Button>
+  )
+}

--- a/src/components/__tests__/SubmitButton.test.tsx
+++ b/src/components/__tests__/SubmitButton.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { vi, expect, test } from 'vitest';
+import { SubmitButton } from '../SubmitButton';
+
+vi.mock('react-dom', async () => {
+  const actual: any = await vi.importActual('react-dom');
+  return { ...actual, useFormStatus: vi.fn(() => ({ pending: false })) };
+});
+
+const { useFormStatus } = await import('react-dom');
+
+test('renders children', () => {
+  const { getByText } = render(<SubmitButton>Send</SubmitButton>);
+  expect(getByText('Send')).toBeTruthy();
+});
+
+test('shows spinner when pending', () => {
+  (useFormStatus as unknown as vi.Mock).mockReturnValueOnce({ pending: true });
+  const { container } = render(<SubmitButton>Send</SubmitButton>);
+  expect(container.querySelector('svg')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- show spinner on delete confirmation button
- add `<SubmitButton>` component with spinner
- add spinner to admin and rotation update forms
- test new button behavior

## Testing
- `npm install`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68541f221f98832792cef0fc3b38550f