### PR TITLE
Enable name editing and fix dropdown styling

### DIFF
--- a/prisma/migrations/20250620033743_allow_duplicate_place/migration.sql
+++ b/prisma/migrations/20250620033743_allow_duplicate_place/migration.sql
@@ -1,0 +1,3 @@
+-- DropIndex
+DROP INDEX "Place_name_key";
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,7 @@ model Member {
 
 model Place {
   id          Int              @id @default(autoincrement())
-  name        String           @unique
+  name        String
   group       Group?           @relation(fields: [groupId], references: [id])
   groupId     Int?
   assignments DutyAssignment[]

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -74,6 +74,24 @@ export default async function AdminPage() {
     revalidatePath("/admin");
   }
 
+  async function updateMemberName(formData: FormData) {
+    "use server";
+    const id = Number(formData.get("memberId"));
+    const name = formData.get("memberName") as string;
+    if (!id || !name) return;
+    await prisma.member.update({ where: { id }, data: { name } });
+    revalidatePath("/admin");
+  }
+
+  async function updatePlaceName(formData: FormData) {
+    "use server";
+    const id = Number(formData.get("placeId"));
+    const name = formData.get("placeName") as string;
+    if (!id || !name) return;
+    await prisma.place.update({ where: { id }, data: { name } });
+    revalidatePath("/admin");
+  }
+
   async function addGroup(formData: FormData) {
     "use server";
     const name = formData.get("groupName") as string;
@@ -163,7 +181,15 @@ export default async function AdminPage() {
         <ul className="divide-y divide-neutral-700 border border-neutral-700 rounded-md">
           {members.map((m) => (
             <li key={m.id} className="flex items-center justify-between px-4 py-2">
-              <span>{m.name}</span>
+              <form action={updateMemberName} className="flex gap-2">
+                <input type="hidden" name="memberId" value={m.id} />
+                <input
+                  name="memberName"
+                  defaultValue={m.name}
+                  className="border px-2 py-1 rounded"
+                />
+                <SubmitButton type="submit" variant="success">保存</SubmitButton>
+              </form>
               <div className="flex gap-2">
                 <form action={updateMemberGroup} className="flex gap-2">
                   <input type="hidden" name="memberId" value={m.id} />
@@ -217,7 +243,15 @@ export default async function AdminPage() {
         <ul className="divide-y divide-neutral-700 border border-neutral-700 rounded-md">
           {places.map((p) => (
             <li key={p.id} className="flex items-center justify-between px-4 py-2">
-              <span>{p.name}</span>
+              <form action={updatePlaceName} className="flex gap-2">
+                <input type="hidden" name="placeId" value={p.id} />
+                <input
+                  name="placeName"
+                  defaultValue={p.name}
+                  className="border px-2 py-1 rounded"
+                />
+                <SubmitButton type="submit" variant="success">保存</SubmitButton>
+              </form>
               <div className="flex gap-2">
                 <form action={updatePlaceGroup} className="flex gap-2">
                   <input type="hidden" name="placeId" value={p.id} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,8 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+select option {
+  background: var(--background);
+  color: var(--foreground);
+}


### PR DESCRIPTION
## Summary of changes
- allow duplicate place names in Prisma schema
- add server actions to update member and place names
- update admin UI to edit names
- fix option styling for dark theme
- add migration for removing unique index on place name

## Related issues
- resolves user request for editable names and dark theme fix

## How to test
- `npm install`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6854d6a31af0832790f1afd9e87c4135