### PR TITLE
Add cleaning duty history view

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,68 @@
+import { prisma } from "@/lib/prisma";
+import { getAssignmentCounts } from "@/lib/history";
+import { format } from "date-fns";
+
+export const dynamic = "force-dynamic";
+
+export default async function HistoryPage() {
+  const weeks = await prisma.week.findMany({
+    orderBy: { startDate: "desc" },
+    include: {
+      assignments: {
+        include: { place: true, member: true },
+        orderBy: { placeId: "asc" },
+      },
+    },
+  });
+
+  const countList = (await getAssignmentCounts()).sort(
+    (a, b) =>
+      a.memberName.localeCompare(b.memberName) ||
+      a.placeName.localeCompare(b.placeName)
+  );
+
+  return (
+    <main className="max-w-4xl mx-auto py-10 flex flex-col gap-10">
+      <section>
+        <h1 className="text-2xl font-bold mb-6">アサイン履歴</h1>
+        <div className="flex flex-col gap-8">
+          {weeks.map((w) => (
+            <div key={w.id} className="border border-neutral-700 rounded-md p-4">
+              <h2 className="text-xl font-semibold mb-2">
+                {format(w.startDate, "yyyy年MM月dd日")}
+              </h2>
+              <ul className="list-disc list-inside space-y-1">
+                {w.assignments.map((a) => (
+                  <li key={a.id}>
+                    {a.place.name}: {a.member.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section>
+        <h2 className="text-xl font-bold mb-4">掃除回数集計</h2>
+        <table className="w-full text-left border-collapse">
+          <thead>
+            <tr>
+              <th className="border-b border-neutral-700 p-2">メンバー</th>
+              <th className="border-b border-neutral-700 p-2">場所</th>
+              <th className="border-b border-neutral-700 p-2 text-right">回数</th>
+            </tr>
+          </thead>
+          <tbody>
+            {countList.map((c, idx) => (
+              <tr key={idx}>
+                <td className="border-b border-neutral-800 p-2">{c.memberName}</td>
+                <td className="border-b border-neutral-800 p-2">{c.placeName}</td>
+                <td className="border-b border-neutral-800 p-2 text-right">{c.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  );
+}

--- a/src/components/SidebarLayout.tsx
+++ b/src/components/SidebarLayout.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { HomeIcon, Cog6ToothIcon } from '@heroicons/react/24/outline'
+import { HomeIcon, Cog6ToothIcon, ClockIcon } from '@heroicons/react/24/outline'
 
 export function SidebarLayout({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false)
@@ -30,6 +30,14 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
           >
             <HomeIcon className="w-5 h-5" />
             <span>トップページ</span>
+          </Link>
+          <Link
+            href="/history"
+            onClick={handleLinkClick}
+            className={`flex items-center gap-3 px-3 py-2 rounded-lg text-neutral-300 hover:bg-neutral-800 hover:text-white ${pathname === '/history' ? 'bg-neutral-800 text-white' : ''}`}
+          >
+            <ClockIcon className="w-5 h-5" />
+            <span>履歴</span>
           </Link>
           <Link
             href="/admin"

--- a/src/lib/__tests__/history.test.ts
+++ b/src/lib/__tests__/history.test.ts
@@ -1,0 +1,43 @@
+import { vi, expect, test } from 'vitest';
+
+vi.mock('../prisma', () => {
+  const prisma = {
+    dutyAssignment: {
+      findMany: vi.fn().mockResolvedValue([
+        {
+          id: 1,
+          memberId: 1,
+          placeId: 1,
+          member: { id: 1, name: 'Alice' },
+          place: { id: 1, name: 'Room' },
+        },
+        {
+          id: 2,
+          memberId: 1,
+          placeId: 1,
+          member: { id: 1, name: 'Alice' },
+          place: { id: 1, name: 'Room' },
+        },
+        {
+          id: 3,
+          memberId: 2,
+          placeId: 2,
+          member: { id: 2, name: 'Bob' },
+          place: { id: 2, name: 'Hall' },
+        },
+      ]),
+    },
+  };
+  return { prisma };
+});
+
+import { getAssignmentCounts } from '../history';
+
+test('aggregates duty counts', async () => {
+  const counts = await getAssignmentCounts();
+  counts.sort((a, b) => a.memberId - b.memberId);
+  expect(counts).toEqual([
+    { memberId: 1, memberName: 'Alice', placeId: 1, placeName: 'Room', count: 2 },
+    { memberId: 2, memberName: 'Bob', placeId: 2, placeName: 'Hall', count: 1 },
+  ]);
+});

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,33 @@
+import { prisma } from './prisma';
+
+export interface CountResult {
+  memberId: number;
+  memberName: string;
+  placeId: number;
+  placeName: string;
+  count: number;
+}
+
+export async function getAssignmentCounts(): Promise<CountResult[]> {
+  const assignments = await prisma.dutyAssignment.findMany({
+    include: { member: true, place: true },
+  });
+
+  const counts: Record<string, CountResult> = {};
+
+  for (const a of assignments) {
+    const key = `${a.memberId}-${a.placeId}`;
+    if (!counts[key]) {
+      counts[key] = {
+        memberId: a.memberId,
+        memberName: a.member.name,
+        placeId: a.placeId,
+        placeName: a.place.name,
+        count: 0,
+      };
+    }
+    counts[key].count++;
+  }
+
+  return Object.values(counts);
+}


### PR DESCRIPTION
## Summary
- show history of weekly duty assignments
- list how many times each member cleaned each place
- link to history page from sidebar
- add tests for history count helper

## Related Issue
- Requested in conversation

## Testing
- `npm install`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855411df9c8832791e44cf02e531741