### PR TITLE
feat: Add tests for untested components

### DIFF
--- a/src/components/SidebarLayout.tsx
+++ b/src/components/SidebarLayout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import React, { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { AppShell, Burger, Group, Stack, NavLink } from '@mantine/core'

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useMantineColorScheme, SegmentedControl } from '@mantine/core'
 import {
   MoonIcon,

--- a/src/components/__tests__/SidebarLayout.test.tsx
+++ b/src/components/__tests__/SidebarLayout.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { MantineProvider } from '@mantine/core'
+import { SidebarLayout } from '../SidebarLayout'
+import { expect, test, vi } from 'vitest'
+
+// Next.jsのusePathnameとLinkをモック
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(() => '/'),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode
+    href: string
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+// ThemeToggleをモック
+vi.mock('../ThemeToggle', () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle">ThemeToggle</div>,
+}))
+
+test('renders SidebarLayout with children', () => {
+  const { getByText } = render(
+    <MantineProvider>
+      <SidebarLayout>
+        <div>Test Content</div>
+      </SidebarLayout>
+    </MantineProvider>
+  )
+
+  expect(getByText('Test Content')).toBeTruthy()
+  expect(getByText('お掃除当番管理')).toBeTruthy()
+})
+
+test('renders all navigation links', () => {
+  const { getAllByText } = render(
+    <MantineProvider>
+      <SidebarLayout>
+        <div>Test Content</div>
+      </SidebarLayout>
+    </MantineProvider>
+  )
+
+  expect(getAllByText('トップページ').length).toBeGreaterThan(0)
+  expect(getAllByText('履歴').length).toBeGreaterThan(0)
+  expect(getAllByText('管理画面').length).toBeGreaterThan(0)
+})
+
+test('renders ThemeToggle component', () => {
+  const { getAllByTestId } = render(
+    <MantineProvider>
+      <SidebarLayout>
+        <div>Test Content</div>
+      </SidebarLayout>
+    </MantineProvider>
+  )
+
+  expect(getAllByTestId('theme-toggle').length).toBeGreaterThan(0)
+})
+
+test('burger menu toggles correctly', () => {
+  const { container } = render(
+    <MantineProvider>
+      <SidebarLayout>
+        <div>Test Content</div>
+      </SidebarLayout>
+    </MantineProvider>
+  )
+
+  // バーガーメニューボタンを探す（Mantineのバーガーメニューのクラス名を使用）
+  const burgerButton = container.querySelector('.mantine-Burger-root')
+  expect(burgerButton).toBeTruthy()
+
+  // クリックしてメニューを開く
+  if (burgerButton) {
+    fireEvent.click(burgerButton)
+  }
+})
+
+test('navigation links close sidebar on click', () => {
+  const { getAllByText } = render(
+    <MantineProvider>
+      <SidebarLayout>
+        <div>Test Content</div>
+      </SidebarLayout>
+    </MantineProvider>
+  )
+
+  // ナビゲーションリンクをクリック
+  const homeLinks = getAllByText('トップページ')
+  expect(homeLinks.length).toBeGreaterThan(0)
+  fireEvent.click(homeLinks[0])
+
+  // リンクがクリック可能であることを確認
+  expect(homeLinks[0]).toBeTruthy()
+})

--- a/src/components/__tests__/Spinner.test.tsx
+++ b/src/components/__tests__/Spinner.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { MantineProvider } from '@mantine/core'
+import { Spinner } from '../Spinner'
+import { expect, test } from 'vitest'
+
+test('renders Spinner component', () => {
+  const { container } = render(
+    <MantineProvider>
+      <Spinner />
+    </MantineProvider>
+  )
+  // MantineのLoaderコンポーネントが含まれているかを確認
+  expect(container.querySelector('[class*="mantine-Loader"]')).toBeTruthy()
+})
+
+test('renders Spinner with custom size', () => {
+  const { container } = render(
+    <MantineProvider>
+      <Spinner size="lg" />
+    </MantineProvider>
+  )
+  expect(container.querySelector('[class*="mantine-Loader"]')).toBeTruthy()
+})
+
+test('renders Spinner with custom color', () => {
+  const { container } = render(
+    <MantineProvider>
+      <Spinner color="red" />
+    </MantineProvider>
+  )
+  expect(container.querySelector('[class*="mantine-Loader"]')).toBeTruthy()
+})
+
+test('renders Spinner with custom className', () => {
+  const { container } = render(
+    <MantineProvider>
+      <Spinner className="custom-spinner" />
+    </MantineProvider>
+  )
+  expect(container.querySelector('.custom-spinner')).toBeTruthy()
+})

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { MantineProvider } from '@mantine/core'
+import { ThemeToggle } from '../ThemeToggle'
+import { expect, test, vi } from 'vitest'
+
+// useMantineColorSchemeをモック
+vi.mock('@mantine/core', async () => {
+  const actual =
+    await vi.importActual<typeof import('@mantine/core')>('@mantine/core')
+  return {
+    ...actual,
+    useMantineColorScheme: vi.fn(() => ({
+      colorScheme: 'light',
+      setColorScheme: vi.fn(),
+    })),
+  }
+})
+
+test('renders ThemeToggle component', async () => {
+  const { container } = render(
+    <MantineProvider>
+      <ThemeToggle />
+    </MantineProvider>
+  )
+
+  // コンポーネントがレンダリングされていることを確認
+  expect(
+    container.querySelector('[class*="mantine-SegmentedControl"]')
+  ).toBeTruthy()
+
+  // マウント後はコンポーネントが機能する
+  await waitFor(() => {
+    expect(
+      container.querySelector('[class*="mantine-SegmentedControl"]')
+    ).toBeTruthy()
+  })
+})
+
+test('renders SegmentedControl with correct aria-label', async () => {
+  const { container } = render(
+    <MantineProvider>
+      <ThemeToggle />
+    </MantineProvider>
+  )
+
+  await waitFor(() => {
+    const segmentedControl = container.querySelector(
+      '[aria-label="Change color scheme"]'
+    )
+    expect(segmentedControl).toBeTruthy()
+  })
+})
+
+test('renders disabled SegmentedControl before mount', () => {
+  const { container } = render(
+    <MantineProvider>
+      <ThemeToggle />
+    </MantineProvider>
+  )
+
+  // SegmentedControlがレンダリングされていることを確認
+  expect(
+    container.querySelector('[class*="mantine-SegmentedControl"]')
+  ).toBeTruthy()
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,3 +11,24 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: () => false,
   }),
 })
+
+// ResizeObserverのモックを追加
+global.ResizeObserver = class ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+  }
+
+  observe() {
+    // モックの実装
+  }
+
+  unobserve() {
+    // モックの実装
+  }
+
+  disconnect() {
+    // モックの実装
+  }
+
+  private callback: ResizeObserverCallback
+}


### PR DESCRIPTION
## Summary
- 未テストだったcomponentsにテストを追加しました
- Spinner、ThemeToggle、SidebarLayoutコンポーネントのテストを実装
- テスト環境の改善（ResizeObserverモック追加、Reactインポート問題修正）

## Test plan
- [x] すべてのテストが通ることを確認済み（22/22 passed）
- [x] フォーマット、型チェック、lintが問題なく通ることを確認済み
- [x] 既存のテストに影響がないことを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)