### PR TITLE
fix: rotation.tsのテストカバレッジを包括的に強化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,17 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".github/**"
-      - "!.github/workflows/**"
+      - '**.md'
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/**'
   push:
     branches: [main]
     paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".github/**"
-      - "!.github/workflows/**"
+      - '**.md'
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/**'
 
 jobs:
   lint-and-test:
@@ -41,8 +41,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci

--- a/src/lib/__tests__/rotation.test.ts
+++ b/src/lib/__tests__/rotation.test.ts
@@ -1,49 +1,447 @@
-import { vi, expect, test, beforeEach, type Mock } from 'vitest'
+import { vi, expect, test, beforeEach, afterEach, describe } from 'vitest'
 
-vi.mock('../prisma', () => {
-  const prisma = {
-    week: { upsert: vi.fn().mockResolvedValue({ id: 1 }) },
+vi.mock('../prisma', () => ({
+  prisma: {
+    week: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
+    },
     place: {
-      findMany: vi.fn().mockResolvedValue([
-        { id: 1, groupId: null },
-        { id: 2, groupId: null },
-      ]),
+      findMany: vi.fn(),
     },
     member: {
-      findMany: vi.fn().mockResolvedValue([
-        { id: 10, groupId: null },
-        { id: 20, groupId: null },
-      ]),
+      findMany: vi.fn(),
     },
-    group: { findMany: vi.fn().mockResolvedValue([]) },
+    group: {
+      findMany: vi.fn(),
+    },
     dutyAssignment: {
-      findMany: vi.fn().mockResolvedValue([]),
+      findMany: vi.fn(),
       create: vi.fn(),
       deleteMany: vi.fn(),
     },
-  }
-  return { prisma }
-})
+  },
+}))
 
+vi.mock('../week', () => ({
+  getWeekStart: vi.fn().mockReturnValue(new Date('2024-01-01T00:00:00Z')),
+}))
+
+import {
+  regenerateThisWeekAssignments,
+  advanceCurrentWeekRotation,
+  autoRotateIfNeeded,
+} from '../rotation'
 import { prisma } from '../prisma'
-import { advanceCurrentWeekRotation } from '../rotation'
 
-const create = prisma.dutyAssignment.create as unknown as Mock
-const deleteMany = prisma.dutyAssignment.deleteMany as unknown as Mock
+// モックされたprismaを型アサーション
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const prismaMock = prisma as any
 
 beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date('2024-01-01T00:00:00Z'))
+  vi.clearAllMocks()
+
+  // デフォルトのモック設定
+  prismaMock.week.upsert.mockResolvedValue({ id: 1 })
+  prismaMock.week.findUnique.mockResolvedValue(null)
+  prismaMock.group.findMany.mockResolvedValue([])
+  prismaMock.member.findMany.mockResolvedValue([])
+  prismaMock.place.findMany.mockResolvedValue([])
+  prismaMock.dutyAssignment.findMany.mockResolvedValue([])
+  prismaMock.dutyAssignment.create.mockResolvedValue({})
+  prismaMock.dutyAssignment.deleteMany.mockResolvedValue({})
 })
 
-test('creates assignments when none exist', async () => {
-  await advanceCurrentWeekRotation()
-  expect(create).toHaveBeenCalledTimes(2)
-  expect(deleteMany).not.toHaveBeenCalled()
-  expect(create).toHaveBeenNthCalledWith(1, {
-    data: { weekId: 1, placeId: 1, memberId: 10 },
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('regenerateThisWeekAssignments', () => {
+  test('グループが存在しない場合は未グループのメンバーと場所で割り当てを作成する', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([])
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: 10, groupId: null },
+      { id: 20, groupId: null },
+    ])
+    prismaMock.place.findMany.mockResolvedValue([
+      { id: 1, groupId: null },
+      { id: 2, groupId: null },
+    ])
+
+    // Act
+    await regenerateThisWeekAssignments()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.deleteMany).toHaveBeenCalledWith({
+      where: { weekId: 1 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledTimes(2)
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(1, {
+      data: { weekId: 1, placeId: 1, memberId: 10 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(2, {
+      data: { weekId: 1, placeId: 2, memberId: 20 },
+    })
   })
-  expect(create).toHaveBeenNthCalledWith(2, {
-    data: { weekId: 1, placeId: 2, memberId: 20 },
+
+  test('グループが存在する場合はグループ内でローテーションを作成する', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'グループA',
+        members: [{ id: 10 }, { id: 20 }, { id: 30 }],
+        places: [{ id: 1 }, { id: 2 }],
+      },
+    ])
+    prismaMock.member.findMany.mockResolvedValue([])
+    prismaMock.place.findMany.mockResolvedValue([])
+
+    // Act
+    await regenerateThisWeekAssignments()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledTimes(2)
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(1, {
+      data: { weekId: 1, placeId: 1, memberId: 10 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(2, {
+      data: { weekId: 1, placeId: 2, memberId: 20 },
+    })
+  })
+
+  test('メンバーが場所より少ない場合は循環して割り当てる', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([])
+    prismaMock.member.findMany.mockResolvedValue([{ id: 10, groupId: null }])
+    prismaMock.place.findMany.mockResolvedValue([
+      { id: 1, groupId: null },
+      { id: 2, groupId: null },
+      { id: 3, groupId: null },
+    ])
+
+    // Act
+    await regenerateThisWeekAssignments()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledTimes(3)
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(1, {
+      data: { weekId: 1, placeId: 1, memberId: 10 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(2, {
+      data: { weekId: 1, placeId: 2, memberId: 10 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(3, {
+      data: { weekId: 1, placeId: 3, memberId: 10 },
+    })
+  })
+
+  test('メンバーまたは場所が0の場合は割り当てを作成しない', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([])
+    prismaMock.member.findMany.mockResolvedValue([])
+    prismaMock.place.findMany.mockResolvedValue([])
+
+    // Act
+    await regenerateThisWeekAssignments()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('advanceCurrentWeekRotation', () => {
+  test('割り当てが存在しない場合は新規作成する', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([])
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: 10, groupId: null },
+      { id: 20, groupId: null },
+    ])
+    prismaMock.place.findMany.mockResolvedValue([
+      { id: 1, groupId: null },
+      { id: 2, groupId: null },
+    ])
+    prismaMock.dutyAssignment.findMany.mockResolvedValue([])
+
+    // Act
+    await advanceCurrentWeekRotation()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledTimes(2)
+    expect(prismaMock.dutyAssignment.deleteMany).not.toHaveBeenCalled()
+  })
+
+  test('既存の割り当てがある場合はローテーションを進める', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([])
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: 10, groupId: null },
+      { id: 20, groupId: null },
+      { id: 30, groupId: null },
+    ])
+    prismaMock.place.findMany.mockResolvedValue([
+      { id: 1, groupId: null },
+      { id: 2, groupId: null },
+    ])
+    prismaMock.dutyAssignment.findMany.mockResolvedValue([
+      { placeId: 1, memberId: 10 },
+      { placeId: 2, memberId: 20 },
+    ])
+
+    // Act
+    await advanceCurrentWeekRotation()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.deleteMany).toHaveBeenCalledWith({
+      where: { weekId: 1, place: { groupId: null } },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledTimes(2)
+    // ローテーション: 最初のメンバー(10)の前のメンバー(30)から開始
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(1, {
+      data: { weekId: 1, placeId: 1, memberId: 30 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(2, {
+      data: { weekId: 1, placeId: 2, memberId: 10 },
+    })
+  })
+
+  test('グループ別に独立してローテーションを処理する', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'グループA',
+        members: [{ id: 10 }, { id: 20 }],
+        places: [{ id: 1 }],
+      },
+    ])
+    prismaMock.member.findMany.mockResolvedValue([])
+    prismaMock.place.findMany.mockResolvedValue([])
+    prismaMock.dutyAssignment.findMany.mockResolvedValue([
+      { placeId: 1, memberId: 10 },
+    ])
+
+    // Act
+    await advanceCurrentWeekRotation()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.deleteMany).toHaveBeenCalledWith({
+      where: { weekId: 1, place: { groupId: 1 } },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledWith({
+      data: { weekId: 1, placeId: 1, memberId: 20 },
+    })
+  })
+})
+
+describe('autoRotateIfNeeded', () => {
+  test('今週の割り当てが既に存在する場合は何もしない', async () => {
+    // Arrange
+    const weekStart = new Date('2024-01-01T00:00:00Z')
+    prismaMock.week.findUnique.mockResolvedValue({
+      id: 1,
+      assignments: [{ id: 1 }],
+    })
+
+    // Act
+    await autoRotateIfNeeded(weekStart)
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).not.toHaveBeenCalled()
+  })
+
+  test('前週の割り当てが存在しない場合は新規作成する', async () => {
+    // Arrange
+    const weekStart = new Date('2024-01-08T00:00:00Z')
+    prismaMock.week.findUnique
+      .mockResolvedValueOnce(null) // 今週
+      .mockResolvedValueOnce(null) // 前週
+    prismaMock.week.upsert.mockResolvedValue({ id: 2 })
+    prismaMock.group.findMany.mockResolvedValue([])
+    prismaMock.member.findMany.mockResolvedValue([{ id: 10, groupId: null }])
+    prismaMock.place.findMany.mockResolvedValue([{ id: 1, groupId: null }])
+
+    // Act
+    await autoRotateIfNeeded(weekStart)
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledWith({
+      data: { weekId: 2, placeId: 1, memberId: 10 },
+    })
+  })
+
+  test('前週の割り当てを基にローテーションを作成する', async () => {
+    // Arrange
+    const weekStart = new Date('2024-01-08T00:00:00Z')
+    prismaMock.week.findUnique
+      .mockResolvedValueOnce(null) // 今週
+      .mockResolvedValueOnce({
+        // 前週
+        id: 1,
+        assignments: [
+          {
+            member: { id: 10 },
+            place: { groupId: null },
+          },
+          {
+            member: { id: 20 },
+            place: { groupId: null },
+          },
+          {
+            member: { id: 30 },
+            place: { groupId: null },
+          },
+        ],
+      })
+    prismaMock.week.upsert.mockResolvedValue({ id: 2 })
+    prismaMock.group.findMany.mockResolvedValue([])
+    // 未グループのメンバーを設定（fetchGroups関数で使用される）
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: 10, groupId: null },
+      { id: 20, groupId: null },
+      { id: 30, groupId: null },
+    ])
+    prismaMock.place.findMany.mockResolvedValue([
+      { id: 1, groupId: null },
+      { id: 2, groupId: null },
+      { id: 3, groupId: null },
+    ])
+
+    // Act
+    await autoRotateIfNeeded(weekStart)
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledTimes(3)
+    // ローテーション: 最後のメンバー(30)が最初に来る
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(1, {
+      data: { weekId: 2, placeId: 1, memberId: 30 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(2, {
+      data: { weekId: 2, placeId: 2, memberId: 10 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(3, {
+      data: { weekId: 2, placeId: 3, memberId: 20 },
+    })
+  })
+
+  test('グループ別に独立してローテーションを処理する', async () => {
+    // Arrange
+    const weekStart = new Date('2024-01-08T00:00:00Z')
+    prismaMock.week.findUnique
+      .mockResolvedValueOnce(null) // 今週
+      .mockResolvedValueOnce({
+        // 前週
+        id: 1,
+        assignments: [
+          {
+            member: { id: 10 },
+            place: { groupId: 1 },
+          },
+          {
+            member: { id: 20 },
+            place: { groupId: 1 },
+          },
+        ],
+      })
+    prismaMock.week.upsert.mockResolvedValue({ id: 2 })
+    prismaMock.group.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'グループA',
+        members: [{ id: 10 }, { id: 20 }],
+        places: [
+          { id: 1, groupId: 1 },
+          { id: 2, groupId: 1 },
+        ],
+      },
+    ])
+    prismaMock.member.findMany.mockResolvedValue([])
+    prismaMock.place.findMany.mockResolvedValue([])
+
+    // Act
+    await autoRotateIfNeeded(weekStart)
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).toHaveBeenCalledTimes(2)
+    // ローテーション: 最後のメンバー(20)が最初に来る
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(1, {
+      data: { weekId: 2, placeId: 1, memberId: 20 },
+    })
+    expect(prismaMock.dutyAssignment.create).toHaveBeenNthCalledWith(2, {
+      data: { weekId: 2, placeId: 2, memberId: 10 },
+    })
+  })
+})
+
+describe('エッジケース', () => {
+  test('メンバーが0人の場合は割り当てを作成しない', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([])
+    prismaMock.member.findMany.mockResolvedValue([])
+    prismaMock.place.findMany.mockResolvedValue([{ id: 1, groupId: null }])
+
+    // Act
+    await regenerateThisWeekAssignments()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).not.toHaveBeenCalled()
+  })
+
+  test('場所が0つの場合は割り当てを作成しない', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([])
+    prismaMock.member.findMany.mockResolvedValue([{ id: 10, groupId: null }])
+    prismaMock.place.findMany.mockResolvedValue([])
+
+    // Act
+    await regenerateThisWeekAssignments()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).not.toHaveBeenCalled()
+  })
+
+  test('グループにメンバーがいない場合はそのグループをスキップする', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'グループA',
+        members: [],
+        places: [{ id: 1 }],
+      },
+    ])
+    prismaMock.member.findMany.mockResolvedValue([])
+    prismaMock.place.findMany.mockResolvedValue([])
+
+    // Act
+    await regenerateThisWeekAssignments()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).not.toHaveBeenCalled()
+  })
+
+  test('グループに場所がない場合はそのグループをスキップする', async () => {
+    // Arrange
+    prismaMock.group.findMany.mockResolvedValue([
+      {
+        id: 1,
+        name: 'グループA',
+        members: [{ id: 10 }],
+        places: [],
+      },
+    ])
+    prismaMock.member.findMany.mockResolvedValue([])
+    prismaMock.place.findMany.mockResolvedValue([])
+
+    // Act
+    await regenerateThisWeekAssignments()
+
+    // Assert
+    expect(prismaMock.dutyAssignment.create).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- rotation.tsファイルの全ての公開関数とプライベート関数のテストカバレッジを大幅に強化
- 従来1つのテストケースのみだった状態から15のテストケースに拡張し、包括的なテストスイートを完成
- 各関数の正常系・異常系・エッジケースを網羅的にテスト

## 追加されたテストカバレッジ

### regenerateThisWeekAssignments関数
- グループなし/ありの場合の割り当て作成
- メンバー数と場所数の比率による循環割り当て
- メンバー・場所が0の場合の処理

### advanceCurrentWeekRotation関数  
- 既存割り当てなしの場合の新規作成
- 既存割り当てからのローテーション進行
- グループ別独立処理

### autoRotateIfNeeded関数
- 既存割り当て存在時のスキップ処理
- 前週なし/ありでのローテーション作成
- グループ別独立処理

### エッジケース
- メンバー0人、場所0つの場合
- 空のグループのスキップ処理

## Test plan
- [x] 全15テストケースが成功
- [x] npm run format実行済み
- [x] npm run type-check実行済み  
- [x] npm run lint実行済み
- [x] fetchGroups関数のロジックも間接的にテスト

🤖 Generated with [Claude Code](https://claude.ai/code)