### PR TITLE
test: src/app/actionsのテストカバレッジ向上

### DIFF
--- a/src/app/actions/__tests__/groups.test.ts
+++ b/src/app/actions/__tests__/groups.test.ts
@@ -1,0 +1,106 @@
+import { vi, expect, test, describe, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    group: {
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/prisma'
+import { addGroup, deleteGroup } from '../groups'
+
+// モックされたprismaを型アサーション
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const prismaMock = prisma as any
+
+describe('Groups Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('addGroup', () => {
+    test('正常にグループを作成する', async () => {
+      const formData = new FormData()
+      formData.set('groupName', 'テストグループ')
+
+      await addGroup(formData)
+
+      expect(prismaMock.group.create).toHaveBeenCalledWith({
+        data: { name: 'テストグループ' },
+      })
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('グループ名が空の場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('groupName', '')
+
+      await addGroup(formData)
+
+      expect(prismaMock.group.create).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+
+    test('グループ名がnullの場合は何もしない', async () => {
+      const formData = new FormData()
+
+      await addGroup(formData)
+
+      expect(prismaMock.group.create).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteGroup', () => {
+    test('正常にグループを削除する', async () => {
+      const formData = new FormData()
+      formData.set('groupId', '1')
+
+      await deleteGroup(formData)
+
+      expect(prismaMock.group.delete).toHaveBeenCalledWith({
+        where: { id: 1 },
+      })
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('グループIDが0の場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('groupId', '0')
+
+      await deleteGroup(formData)
+
+      expect(prismaMock.group.delete).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+
+    test('グループIDがnullの場合は何もしない', async () => {
+      const formData = new FormData()
+
+      await deleteGroup(formData)
+
+      expect(prismaMock.group.delete).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+
+    test('グループIDが無効な値の場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('groupId', 'invalid')
+
+      await deleteGroup(formData)
+
+      expect(prismaMock.group.delete).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/app/actions/__tests__/members.test.ts
+++ b/src/app/actions/__tests__/members.test.ts
@@ -1,0 +1,211 @@
+import { vi, expect, test, describe, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    member: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+    },
+    week: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+vi.mock('@/lib/rotation', () => ({
+  regenerateThisWeekAssignments: vi.fn(),
+}))
+
+vi.mock('@/lib/week', () => ({
+  getWeekStart: vi.fn(() => new Date('2023-01-02')), // 月曜日
+}))
+
+import { revalidatePath } from 'next/cache'
+import { regenerateThisWeekAssignments } from '@/lib/rotation'
+import { getWeekStart } from '@/lib/week'
+import { prisma } from '@/lib/prisma'
+import {
+  addMember,
+  deleteMember,
+  updateMemberName,
+  updateMemberGroup,
+} from '../members'
+
+// モックされたprismaを型アサーション
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const prismaMock = prisma as any
+
+describe('Members Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('addMember', () => {
+    test('正常にメンバーを作成する（グループ指定あり）', async () => {
+      const formData = new FormData()
+      formData.set('memberName', 'テストメンバー')
+      formData.set('memberGroupId', '1')
+
+      await addMember(formData)
+
+      expect(prismaMock.member.create).toHaveBeenCalledWith({
+        data: { name: 'テストメンバー', groupId: 1 },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('正常にメンバーを作成する（グループ指定なし）', async () => {
+      const formData = new FormData()
+      formData.set('memberName', 'テストメンバー')
+
+      await addMember(formData)
+
+      expect(prismaMock.member.create).toHaveBeenCalledWith({
+        data: { name: 'テストメンバー', groupId: null },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('メンバー名が空の場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('memberName', '')
+
+      await addMember(formData)
+
+      expect(prismaMock.member.create).not.toHaveBeenCalled()
+      expect(regenerateThisWeekAssignments).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteMember', () => {
+    test('正常にメンバーを削除する（当番割当あり）', async () => {
+      const formData = new FormData()
+      formData.set('memberId', '1')
+
+      prismaMock.week.findUnique.mockResolvedValue({
+        assignments: [{ memberId: 1 }],
+      })
+
+      await deleteMember(formData)
+
+      expect(getWeekStart).toHaveBeenCalled()
+      expect(prismaMock.week.findUnique).toHaveBeenCalledWith({
+        where: { startDate: new Date('2023-01-02') },
+        include: { assignments: true },
+      })
+      expect(prismaMock.member.delete).toHaveBeenCalledWith({
+        where: { id: 1 },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('正常にメンバーを削除する（当番割当なし）', async () => {
+      const formData = new FormData()
+      formData.set('memberId', '1')
+
+      prismaMock.week.findUnique.mockResolvedValue({
+        assignments: [{ memberId: 2 }],
+      })
+
+      await deleteMember(formData)
+
+      expect(prismaMock.member.delete).toHaveBeenCalledWith({
+        where: { id: 1 },
+      })
+      expect(regenerateThisWeekAssignments).not.toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('メンバーIDが0の場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('memberId', '0')
+
+      await deleteMember(formData)
+
+      expect(prismaMock.member.delete).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateMemberName', () => {
+    test('正常にメンバー名を更新する', async () => {
+      const formData = new FormData()
+      formData.set('memberId', '1')
+      formData.set('memberName', '新しい名前')
+
+      await updateMemberName(formData)
+
+      expect(prismaMock.member.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { name: '新しい名前' },
+      })
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('IDまたは名前が無効な場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('memberId', '0')
+      formData.set('memberName', '新しい名前')
+
+      await updateMemberName(formData)
+
+      expect(prismaMock.member.update).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateMemberGroup', () => {
+    test('正常にメンバーのグループを更新する', async () => {
+      const formData = new FormData()
+      formData.set('memberId', '1')
+      formData.set('memberGroupId', '2')
+
+      await updateMemberGroup(formData)
+
+      expect(prismaMock.member.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { groupId: 2 },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('グループIDをnullに更新する', async () => {
+      const formData = new FormData()
+      formData.set('memberId', '1')
+
+      await updateMemberGroup(formData)
+
+      expect(prismaMock.member.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { groupId: null },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+    })
+
+    test('メンバーIDが無効な場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('memberId', '0')
+
+      await updateMemberGroup(formData)
+
+      expect(prismaMock.member.update).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/app/actions/__tests__/places.test.ts
+++ b/src/app/actions/__tests__/places.test.ts
@@ -1,0 +1,211 @@
+import { vi, expect, test, describe, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    place: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+    },
+    week: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+vi.mock('@/lib/rotation', () => ({
+  regenerateThisWeekAssignments: vi.fn(),
+}))
+
+vi.mock('@/lib/week', () => ({
+  getWeekStart: vi.fn(() => new Date('2023-01-02')), // 月曜日
+}))
+
+import { revalidatePath } from 'next/cache'
+import { regenerateThisWeekAssignments } from '@/lib/rotation'
+import { getWeekStart } from '@/lib/week'
+import { prisma } from '@/lib/prisma'
+import {
+  addPlace,
+  deletePlace,
+  updatePlaceName,
+  updatePlaceGroup,
+} from '../places'
+
+// モックされたprismaを型アサーション
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const prismaMock = prisma as any
+
+describe('Places Actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('addPlace', () => {
+    test('正常に場所を作成する（グループ指定あり）', async () => {
+      const formData = new FormData()
+      formData.set('placeName', 'テスト場所')
+      formData.set('placeGroupId', '1')
+
+      await addPlace(formData)
+
+      expect(prismaMock.place.create).toHaveBeenCalledWith({
+        data: { name: 'テスト場所', groupId: 1 },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('正常に場所を作成する（グループ指定なし）', async () => {
+      const formData = new FormData()
+      formData.set('placeName', 'テスト場所')
+
+      await addPlace(formData)
+
+      expect(prismaMock.place.create).toHaveBeenCalledWith({
+        data: { name: 'テスト場所', groupId: null },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('場所名が空の場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('placeName', '')
+
+      await addPlace(formData)
+
+      expect(prismaMock.place.create).not.toHaveBeenCalled()
+      expect(regenerateThisWeekAssignments).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deletePlace', () => {
+    test('正常に場所を削除する（当番割当あり）', async () => {
+      const formData = new FormData()
+      formData.set('placeId', '1')
+
+      prismaMock.week.findUnique.mockResolvedValue({
+        assignments: [{ placeId: 1 }],
+      })
+
+      await deletePlace(formData)
+
+      expect(getWeekStart).toHaveBeenCalled()
+      expect(prismaMock.week.findUnique).toHaveBeenCalledWith({
+        where: { startDate: new Date('2023-01-02') },
+        include: { assignments: true },
+      })
+      expect(prismaMock.place.delete).toHaveBeenCalledWith({
+        where: { id: 1 },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('正常に場所を削除する（当番割当なし）', async () => {
+      const formData = new FormData()
+      formData.set('placeId', '1')
+
+      prismaMock.week.findUnique.mockResolvedValue({
+        assignments: [{ placeId: 2 }],
+      })
+
+      await deletePlace(formData)
+
+      expect(prismaMock.place.delete).toHaveBeenCalledWith({
+        where: { id: 1 },
+      })
+      expect(regenerateThisWeekAssignments).not.toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('場所IDが0の場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('placeId', '0')
+
+      await deletePlace(formData)
+
+      expect(prismaMock.place.delete).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updatePlaceName', () => {
+    test('正常に場所名を更新する', async () => {
+      const formData = new FormData()
+      formData.set('placeId', '1')
+      formData.set('placeName', '新しい場所名')
+
+      await updatePlaceName(formData)
+
+      expect(prismaMock.place.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { name: '新しい場所名' },
+      })
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('IDまたは名前が無効な場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('placeId', '0')
+      formData.set('placeName', '新しい場所名')
+
+      await updatePlaceName(formData)
+
+      expect(prismaMock.place.update).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updatePlaceGroup', () => {
+    test('正常に場所のグループを更新する', async () => {
+      const formData = new FormData()
+      formData.set('placeId', '1')
+      formData.set('placeGroupId', '2')
+
+      await updatePlaceGroup(formData)
+
+      expect(prismaMock.place.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { groupId: 2 },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+      expect(revalidatePath).toHaveBeenCalledWith('/admin')
+      expect(revalidatePath).toHaveBeenCalledWith('/')
+    })
+
+    test('グループIDをnullに更新する', async () => {
+      const formData = new FormData()
+      formData.set('placeId', '1')
+
+      await updatePlaceGroup(formData)
+
+      expect(prismaMock.place.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { groupId: null },
+      })
+      expect(regenerateThisWeekAssignments).toHaveBeenCalled()
+    })
+
+    test('場所IDが無効な場合は何もしない', async () => {
+      const formData = new FormData()
+      formData.set('placeId', '0')
+
+      await updatePlaceGroup(formData)
+
+      expect(prismaMock.place.update).not.toHaveBeenCalled()
+      expect(revalidatePath).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

src/app/actions以下のアクションで、カバーされていないファイルのテストを新規作成し、テストカバレッジを向上させました。

• `groups.test.ts` - groups.tsのaddGroup, deleteGroup関数のテスト追加
• `members.test.ts` - members.tsの4つの関数（addMember, deleteMember, updateMemberName, updateMemberGroup）のテスト追加  
• `places.test.ts` - places.tsの4つの関数（addPlace, deletePlace, updatePlaceName, updatePlaceGroup）のテスト追加

## Test plan

✅ 新規テストファイルが正常に実行され、全29個のテストケースが成功
✅ 既存テストが破綻していないことを確認（全65テストが成功）
✅ フォーマット、型チェック、Lintが全て成功
✅ Server Actionsの正常系・異常系をカバー
✅ Prismaのモック化とrevalidatePathの呼び出しを適切に検証

🤖 Generated with [Claude Code](https://claude.ai/code)