### PR TITLE
feat: HistoryContentコンポーネントのテストを追加

### DIFF
--- a/src/app/history/__tests__/HistoryContent.test.tsx
+++ b/src/app/history/__tests__/HistoryContent.test.tsx
@@ -21,6 +21,9 @@ vi.mock('date-fns', () => ({
 import { prisma } from '@/lib/prisma'
 import { getAssignmentCounts, type CountResult } from '@/lib/history'
 
+// 型安全なモック関数
+const mockGetAssignmentCounts = vi.mocked(getAssignmentCounts)
+
 // モックされたprismaを型アサーション
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const prismaMock = prisma as any
@@ -69,9 +72,7 @@ beforeEach(() => {
 
   // デフォルトのモック設定
   prismaMock.week.findMany.mockResolvedValue([])
-  ;(
-    getAssignmentCounts as vi.MockedFunction<typeof getAssignmentCounts>
-  ).mockResolvedValue([])
+  mockGetAssignmentCounts.mockResolvedValue([])
 })
 
 afterEach(() => {
@@ -82,9 +83,7 @@ describe('HistoryContentData Logic', () => {
   test('データがない場合に空の配列とオブジェクトを返す', async () => {
     // Arrange
     prismaMock.week.findMany.mockResolvedValue([])
-    ;(
-      getAssignmentCounts as vi.MockedFunction<typeof getAssignmentCounts>
-    ).mockResolvedValue([])
+    mockGetAssignmentCounts.mockResolvedValue([])
 
     // Act
     const result = await getHistoryContentData()
@@ -136,9 +135,7 @@ describe('HistoryContentData Logic', () => {
     ]
 
     prismaMock.week.findMany.mockResolvedValue(mockWeeks)
-    ;(
-      getAssignmentCounts as vi.MockedFunction<typeof getAssignmentCounts>
-    ).mockResolvedValue([])
+    mockGetAssignmentCounts.mockResolvedValue([])
 
     // Act
     const result = await getHistoryContentData()
@@ -177,9 +174,7 @@ describe('HistoryContentData Logic', () => {
     ]
 
     prismaMock.week.findMany.mockResolvedValue([])
-    ;(
-      getAssignmentCounts as vi.MockedFunction<typeof getAssignmentCounts>
-    ).mockResolvedValue(mockCountList)
+    mockGetAssignmentCounts.mockResolvedValue(mockCountList)
 
     // Act
     const result = await getHistoryContentData()
@@ -237,9 +232,7 @@ describe('HistoryContentData Logic', () => {
     ]
 
     prismaMock.week.findMany.mockResolvedValue([])
-    ;(
-      getAssignmentCounts as vi.MockedFunction<typeof getAssignmentCounts>
-    ).mockResolvedValue(mockCountList)
+    mockGetAssignmentCounts.mockResolvedValue(mockCountList)
 
     // Act
     const result = await getHistoryContentData()
@@ -276,9 +269,7 @@ describe('HistoryContentData Logic', () => {
     ]
 
     prismaMock.week.findMany.mockResolvedValue([])
-    ;(
-      getAssignmentCounts as vi.MockedFunction<typeof getAssignmentCounts>
-    ).mockResolvedValue(mockCountList)
+    mockGetAssignmentCounts.mockResolvedValue(mockCountList)
 
     // Act
     const result = await getHistoryContentData()
@@ -348,9 +339,7 @@ describe('HistoryContentData Logic', () => {
     ]
 
     prismaMock.week.findMany.mockResolvedValue(mockWeeks)
-    ;(
-      getAssignmentCounts as vi.MockedFunction<typeof getAssignmentCounts>
-    ).mockResolvedValue(mockCountList)
+    mockGetAssignmentCounts.mockResolvedValue(mockCountList)
 
     // Act
     const result = await getHistoryContentData()
@@ -374,9 +363,9 @@ describe('HistoryContentData Logic', () => {
   test('getAssignmentCountsでエラーが発生した場合に適切にエラーを投げる', async () => {
     // Arrange
     prismaMock.week.findMany.mockResolvedValue([])
-    ;(
-      getAssignmentCounts as vi.MockedFunction<typeof getAssignmentCounts>
-    ).mockRejectedValue(new Error('Assignment count error'))
+    mockGetAssignmentCounts.mockRejectedValue(
+      new Error('Assignment count error')
+    )
 
     // Act & Assert
     await expect(getHistoryContentData()).rejects.toThrow(


### PR DESCRIPTION
## Summary
- HistoryContentコンポーネントのロジック部分の包括的テストを作成
- 週データ取得・整理、掃除回数集計・マトリックス構築の全8テストケース
- Prismaクライアントとhistory関数を適切にモック化

## Test plan
- [x] HistoryContentのデータロジック部分の単体テスト作成
- [x] 空データケースのテスト
- [x] 週データ取得・整理のテスト  
- [x] 掃除回数データソート・マトリックス構築のテスト
- [x] メンバー名・場所名ソート処理のテスト
- [x] 複数週・複数メンバー・場所の複合ケースのテスト
- [x] データベースエラーハンドリングのテスト
- [x] 全テスト実行 (80件) 成功
- [x] lint、型チェック、フォーマット完了

🤖 Generated with [Claude Code](https://claude.ai/code)