### PR TITLE
feat: HistoryContentコンポーネントのビジネスロジック分離とテスト追加

### DIFF
--- a/src/app/history/HistoryContent.tsx
+++ b/src/app/history/HistoryContent.tsx
@@ -1,5 +1,8 @@
-import { getAssignmentCounts } from '@/lib/history'
-import { prisma } from '@/lib/prisma'
+import React from 'react'
+import {
+  getWeeksWithAssignments,
+  getCleaningCountMatrix,
+} from '@/lib/history-data'
 import {
   Card,
   Table,
@@ -12,33 +15,8 @@ import {
 import { format } from 'date-fns'
 
 export async function HistoryContent() {
-  const weeks = await prisma.week.findMany({
-    orderBy: { startDate: 'desc' },
-    include: {
-      assignments: {
-        include: { place: true, member: true },
-        orderBy: { placeId: 'asc' },
-      },
-    },
-  })
-
-  const countList = (await getAssignmentCounts()).sort(
-    (a, b) =>
-      a.memberName.localeCompare(b.memberName) ||
-      a.placeName.localeCompare(b.placeName)
-  )
-
-  const members = Array.from(new Set(countList.map(c => c.memberName))).sort(
-    (a, b) => a.localeCompare(b)
-  )
-  const places = Array.from(new Set(countList.map(c => c.placeName))).sort(
-    (a, b) => a.localeCompare(b)
-  )
-  const matrix: Record<string, Record<string, number>> = {}
-  for (const c of countList) {
-    if (!matrix[c.memberName]) matrix[c.memberName] = {}
-    matrix[c.memberName][c.placeName] = c.count
-  }
+  const weeks = await getWeeksWithAssignments()
+  const { members, places, matrix } = await getCleaningCountMatrix()
 
   return (
     <>

--- a/src/app/history/__tests__/HistoryContent.test.tsx
+++ b/src/app/history/__tests__/HistoryContent.test.tsx
@@ -1,375 +1,185 @@
+import React from 'react'
 import { vi, expect, test, beforeEach, afterEach, describe } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MantineProvider } from '@mantine/core'
 
-// Prismaクライアントのモック化
-vi.mock('@/lib/prisma', () => ({
-  prisma: {
-    week: {
-      findMany: vi.fn(),
-    },
+const mockWeeks = [
+  {
+    id: 1,
+    startDate: new Date('2024-01-01'),
+    assignments: [
+      {
+        id: 1,
+        placeId: 1,
+        memberId: 1,
+        place: { id: 1, name: 'キッチン' },
+        member: { id: 1, name: '田中太郎' },
+      },
+      {
+        id: 2,
+        placeId: 2,
+        memberId: 2,
+        place: { id: 2, name: 'トイレ' },
+        member: { id: 2, name: '佐藤花子' },
+      },
+    ],
   },
-}))
+  {
+    id: 2,
+    startDate: new Date('2024-01-08'),
+    assignments: [
+      {
+        id: 3,
+        placeId: 1,
+        memberId: 2,
+        place: { id: 1, name: 'キッチン' },
+        member: { id: 2, name: '佐藤花子' },
+      },
+    ],
+  },
+]
+
+const mockCountMatrix = {
+  members: ['佐藤花子', '田中太郎'],
+  places: ['キッチン', 'トイレ'],
+  matrix: {
+    田中太郎: { キッチン: 1, トイレ: 1 },
+    佐藤花子: { キッチン: 2 },
+  },
+}
 
 // 外部依存関数のモック化
-vi.mock('@/lib/history', () => ({
-  getAssignmentCounts: vi.fn(),
+vi.mock('@/lib/history-data', () => ({
+  getWeeksWithAssignments: vi.fn(),
+  getCleaningCountMatrix: vi.fn(),
 }))
 
 vi.mock('date-fns', () => ({
-  format: vi.fn(() => '2024年01月01日'),
+  format: vi.fn((date: Date) => {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}年${month}月${day}日`
+  }),
 }))
 
-import { prisma } from '@/lib/prisma'
-import { getAssignmentCounts, type CountResult } from '@/lib/history'
+import {
+  getWeeksWithAssignments,
+  getCleaningCountMatrix,
+} from '@/lib/history-data'
+import { HistoryContent } from '../HistoryContent'
 
-// 型安全なモック関数
-const mockGetAssignmentCounts = vi.mocked(getAssignmentCounts)
-
-// モックされたprismaを型アサーション
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const prismaMock = prisma as any
-
-// HistoryContentコンポーネントのロジック部分を抽出したテスト用関数
-async function getHistoryContentData() {
-  const weeks = await prisma.week.findMany({
-    orderBy: { startDate: 'desc' },
-    include: {
-      assignments: {
-        include: { place: true, member: true },
-        orderBy: { placeId: 'asc' },
-      },
-    },
-  })
-
-  const countList = (await getAssignmentCounts()).sort(
-    (a, b) =>
-      a.memberName.localeCompare(b.memberName) ||
-      a.placeName.localeCompare(b.placeName)
-  )
-
-  const members = Array.from(new Set(countList.map(c => c.memberName))).sort(
-    (a, b) => a.localeCompare(b)
-  )
-  const places = Array.from(new Set(countList.map(c => c.placeName))).sort(
-    (a, b) => a.localeCompare(b)
-  )
-  const matrix: Record<string, Record<string, number>> = {}
-  for (const c of countList) {
-    if (!matrix[c.memberName]) matrix[c.memberName] = {}
-    matrix[c.memberName][c.placeName] = c.count
-  }
-
-  return {
-    weeks,
-    countList,
-    members,
-    places,
-    matrix,
-  }
-}
+const mockGetWeeksWithAssignments = vi.mocked(getWeeksWithAssignments)
+const mockGetCleaningCountMatrix = vi.mocked(getCleaningCountMatrix)
 
 beforeEach(() => {
   vi.clearAllMocks()
 
   // デフォルトのモック設定
-  prismaMock.week.findMany.mockResolvedValue([])
-  mockGetAssignmentCounts.mockResolvedValue([])
+  mockGetWeeksWithAssignments.mockResolvedValue(mockWeeks)
+  mockGetCleaningCountMatrix.mockResolvedValue(mockCountMatrix)
 })
 
 afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('HistoryContentData Logic', () => {
-  test('データがない場合に空の配列とオブジェクトを返す', async () => {
-    // Arrange
-    prismaMock.week.findMany.mockResolvedValue([])
-    mockGetAssignmentCounts.mockResolvedValue([])
+// サーバーコンポーネント用のレンダリングヘルパー
+async function renderHistoryContent() {
+  const jsx = await HistoryContent()
+  return render(<MantineProvider>{jsx}</MantineProvider>)
+}
 
+describe('HistoryContent', () => {
+  test('アサイン履歴セクションが正しく表示される', async () => {
     // Act
-    const result = await getHistoryContentData()
+    await renderHistoryContent()
 
     // Assert
-    expect(result.weeks).toEqual([])
-    expect(result.countList).toEqual([])
-    expect(result.members).toEqual([])
-    expect(result.places).toEqual([])
-    expect(result.matrix).toEqual({})
+    expect(screen.getByText('アサイン履歴')).toBeInTheDocument()
+    expect(screen.getByText('2024年01月01日')).toBeInTheDocument()
+    expect(screen.getByText('2024年01月08日')).toBeInTheDocument()
   })
 
-  test('週データが存在する場合に適切に整理される', async () => {
-    // Arrange
-    const mockWeeks = [
-      {
-        id: 1,
-        startDate: new Date('2024-01-01'),
-        assignments: [
-          {
-            id: 1,
-            placeId: 1,
-            memberId: 1,
-            place: { id: 1, name: 'キッチン' },
-            member: { id: 1, name: '田中太郎' },
-          },
-          {
-            id: 2,
-            placeId: 2,
-            memberId: 2,
-            place: { id: 2, name: 'トイレ' },
-            member: { id: 2, name: '佐藤花子' },
-          },
-        ],
-      },
-      {
-        id: 2,
-        startDate: new Date('2024-01-08'),
-        assignments: [
-          {
-            id: 3,
-            placeId: 1,
-            memberId: 2,
-            place: { id: 1, name: 'キッチン' },
-            member: { id: 2, name: '佐藤花子' },
-          },
-        ],
-      },
-    ]
-
-    prismaMock.week.findMany.mockResolvedValue(mockWeeks)
-    mockGetAssignmentCounts.mockResolvedValue([])
-
+  test('アサイン履歴の詳細が正しく表示される', async () => {
     // Act
-    const result = await getHistoryContentData()
+    await renderHistoryContent()
 
     // Assert
-    expect(result.weeks).toEqual(mockWeeks)
-    expect(result.weeks).toHaveLength(2)
-    expect(result.weeks[0].assignments).toHaveLength(2)
-    expect(result.weeks[1].assignments).toHaveLength(1)
+    expect(screen.getByText('キッチン: 田中太郎')).toBeInTheDocument()
+    expect(screen.getByText('トイレ: 佐藤花子')).toBeInTheDocument()
+    expect(screen.getByText('キッチン: 佐藤花子')).toBeInTheDocument()
   })
 
-  test('掃除回数データを正しくソートし、マトリックスを構築する', async () => {
-    // Arrange
-    const mockCountList: CountResult[] = [
-      {
-        memberId: 2,
-        memberName: '佐藤花子',
-        placeId: 1,
-        placeName: 'キッチン',
-        count: 3,
-      },
-      {
-        memberId: 1,
-        memberName: '田中太郎',
-        placeId: 2,
-        placeName: 'トイレ',
-        count: 2,
-      },
-      {
-        memberId: 1,
-        memberName: '田中太郎',
-        placeId: 1,
-        placeName: 'キッチン',
-        count: 1,
-      },
-    ]
-
-    prismaMock.week.findMany.mockResolvedValue([])
-    mockGetAssignmentCounts.mockResolvedValue(mockCountList)
-
+  test('掃除回数集計テーブルが正しく表示される', async () => {
     // Act
-    const result = await getHistoryContentData()
+    await renderHistoryContent()
 
     // Assert
-    // ソート後の順序を確認（日本語文字列ソート順）
-    expect(result.countList).toHaveLength(3)
-    expect(result.countList[0]).toEqual({
-      memberId: 2,
-      memberName: '佐藤花子',
-      placeId: 1,
-      placeName: 'キッチン',
-      count: 3,
-    })
-    expect(result.countList[1]).toEqual({
-      memberId: 1,
-      memberName: '田中太郎',
-      placeId: 1,
-      placeName: 'キッチン',
-      count: 1,
-    })
-    expect(result.countList[2]).toEqual({
-      memberId: 1,
-      memberName: '田中太郎',
-      placeId: 2,
-      placeName: 'トイレ',
-      count: 2,
-    })
+    expect(screen.getByText('掃除回数集計')).toBeInTheDocument()
+    expect(screen.getByText('メンバー\\場所')).toBeInTheDocument()
+    expect(screen.getByText('田中太郎')).toBeInTheDocument()
+    expect(screen.getByText('佐藤花子')).toBeInTheDocument()
   })
 
-  test('メンバー名と場所名が正しくソートされる', async () => {
-    // Arrange
-    const mockCountList: CountResult[] = [
-      {
-        memberId: 3,
-        memberName: '鈴木次郎',
-        placeId: 3,
-        placeName: 'リビング',
-        count: 1,
-      },
-      {
-        memberId: 1,
-        memberName: '田中太郎',
-        placeId: 1,
-        placeName: 'キッチン',
-        count: 2,
-      },
-      {
-        memberId: 2,
-        memberName: '佐藤花子',
-        placeId: 2,
-        placeName: 'トイレ',
-        count: 3,
-      },
-    ]
-
-    prismaMock.week.findMany.mockResolvedValue([])
-    mockGetAssignmentCounts.mockResolvedValue(mockCountList)
-
+  test('掃除回数集計テーブルの場所ヘッダーが正しく表示される', async () => {
     // Act
-    const result = await getHistoryContentData()
+    await renderHistoryContent()
 
     // Assert
-    expect(result.members).toEqual(['佐藤花子', '田中太郎', '鈴木次郎'])
-    expect(result.places).toEqual(['キッチン', 'トイレ', 'リビング'])
+    const tableHeaders = screen.getAllByText('キッチン')
+    const tableHeaders2 = screen.getAllByText('トイレ')
+    expect(tableHeaders.length).toBeGreaterThan(0)
+    expect(tableHeaders2.length).toBeGreaterThan(0)
   })
 
-  test('マトリックス構造が正しく構築される', async () => {
-    // Arrange
-    const mockCountList: CountResult[] = [
-      {
-        memberId: 1,
-        memberName: '田中太郎',
-        placeId: 1,
-        placeName: 'キッチン',
-        count: 2,
-      },
-      {
-        memberId: 1,
-        memberName: '田中太郎',
-        placeId: 2,
-        placeName: 'トイレ',
-        count: 1,
-      },
-      {
-        memberId: 2,
-        memberName: '佐藤花子',
-        placeId: 1,
-        placeName: 'キッチン',
-        count: 3,
-      },
-    ]
-
-    prismaMock.week.findMany.mockResolvedValue([])
-    mockGetAssignmentCounts.mockResolvedValue(mockCountList)
-
+  test('掃除回数の数値が正しく表示される', async () => {
     // Act
-    const result = await getHistoryContentData()
+    await renderHistoryContent()
 
     // Assert
-    expect(result.matrix).toEqual({
-      田中太郎: {
-        キッチン: 2,
-        トイレ: 1,
-      },
-      佐藤花子: {
-        キッチン: 3,
-      },
+    expect(screen.getAllByText('1')).toHaveLength(2)
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  test('空のデータの場合でも正しく表示される', async () => {
+    // Arrange
+    mockGetWeeksWithAssignments.mockResolvedValue([])
+    mockGetCleaningCountMatrix.mockResolvedValue({
+      members: [],
+      places: [],
+      matrix: {},
     })
 
-    // 未割当場所の値確認（0が返されるべき）
-    expect(result.matrix['田中太郎']['トイレ']).toBe(1)
-    expect(result.matrix['佐藤花子']['トイレ']).toBeUndefined() // 未設定
-  })
-
-  test('複数週と複数メンバー・場所の複合ケース', async () => {
-    // Arrange
-    const mockWeeks = [
-      {
-        id: 1,
-        startDate: new Date('2024-01-01'),
-        assignments: [
-          {
-            id: 1,
-            placeId: 1,
-            memberId: 1,
-            place: { id: 1, name: 'キッチン' },
-            member: { id: 1, name: '田中太郎' },
-          },
-        ],
-      },
-      {
-        id: 2,
-        startDate: new Date('2024-01-08'),
-        assignments: [
-          {
-            id: 2,
-            placeId: 2,
-            memberId: 2,
-            place: { id: 2, name: 'トイレ' },
-            member: { id: 2, name: '佐藤花子' },
-          },
-        ],
-      },
-    ]
-
-    const mockCountList: CountResult[] = [
-      {
-        memberId: 1,
-        memberName: '田中太郎',
-        placeId: 1,
-        placeName: 'キッチン',
-        count: 1,
-      },
-      {
-        memberId: 2,
-        memberName: '佐藤花子',
-        placeId: 2,
-        placeName: 'トイレ',
-        count: 1,
-      },
-    ]
-
-    prismaMock.week.findMany.mockResolvedValue(mockWeeks)
-    mockGetAssignmentCounts.mockResolvedValue(mockCountList)
-
     // Act
-    const result = await getHistoryContentData()
+    await renderHistoryContent()
 
     // Assert
-    expect(result.weeks).toHaveLength(2)
-    expect(result.members).toEqual(['佐藤花子', '田中太郎'])
-    expect(result.places).toEqual(['キッチン', 'トイレ'])
-    expect(result.matrix['田中太郎']['キッチン']).toBe(1)
-    expect(result.matrix['佐藤花子']['トイレ']).toBe(1)
+    expect(screen.getByText('アサイン履歴')).toBeInTheDocument()
+    expect(screen.getByText('掃除回数集計')).toBeInTheDocument()
+    expect(screen.getByText('メンバー\\場所')).toBeInTheDocument()
   })
 
-  test('データベースエラーが発生した場合に適切にエラーを投げる', async () => {
-    // Arrange
-    prismaMock.week.findMany.mockRejectedValue(new Error('Database error'))
+  test('週のデータが時系列順（降順）で表示される', async () => {
+    // Act
+    await renderHistoryContent()
 
-    // Act & Assert
-    await expect(getHistoryContentData()).rejects.toThrow('Database error')
+    // Assert
+    const weekHeaders = screen.getAllByText(/\d{4}年\d{2}月\d{2}日/)
+    expect(weekHeaders).toHaveLength(2)
+
+    // 最初に表示されるのは新しい週（2024年01月01日）
+    expect(weekHeaders[0]).toHaveTextContent('2024年01月01日')
+    expect(weekHeaders[1]).toHaveTextContent('2024年01月08日')
   })
 
-  test('getAssignmentCountsでエラーが発生した場合に適切にエラーを投げる', async () => {
-    // Arrange
-    prismaMock.week.findMany.mockResolvedValue([])
-    mockGetAssignmentCounts.mockRejectedValue(
-      new Error('Assignment count error')
-    )
+  test('ビジネスロジック関数が正しく呼び出される', async () => {
+    // Act
+    await renderHistoryContent()
 
-    // Act & Assert
-    await expect(getHistoryContentData()).rejects.toThrow(
-      'Assignment count error'
-    )
+    // Assert
+    expect(mockGetWeeksWithAssignments).toHaveBeenCalledTimes(1)
+    expect(mockGetCleaningCountMatrix).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/lib/__tests__/history-data.test.ts
+++ b/src/lib/__tests__/history-data.test.ts
@@ -1,0 +1,114 @@
+import { vi, expect, test, describe } from 'vitest'
+
+vi.mock('../prisma', () => {
+  const mockWeeks = [
+    {
+      id: 1,
+      startDate: new Date('2023-01-02'),
+      assignments: [
+        {
+          id: 1,
+          placeId: 1,
+          memberId: 1,
+          place: { id: 1, name: 'Room' },
+          member: { id: 1, name: 'Alice' },
+        },
+      ],
+    },
+    {
+      id: 2,
+      startDate: new Date('2023-01-09'),
+      assignments: [
+        {
+          id: 2,
+          placeId: 2,
+          memberId: 2,
+          place: { id: 2, name: 'Hall' },
+          member: { id: 2, name: 'Bob' },
+        },
+      ],
+    },
+  ]
+
+  const prisma = {
+    week: {
+      findMany: vi.fn().mockResolvedValue(mockWeeks),
+    },
+  }
+  return { prisma }
+})
+
+vi.mock('../history', () => {
+  const mockCountList = [
+    {
+      memberId: 1,
+      memberName: 'Alice',
+      placeId: 1,
+      placeName: 'Room',
+      count: 2,
+    },
+    {
+      memberId: 2,
+      memberName: 'Bob',
+      placeId: 2,
+      placeName: 'Hall',
+      count: 1,
+    },
+    {
+      memberId: 1,
+      memberName: 'Alice',
+      placeId: 2,
+      placeName: 'Hall',
+      count: 1,
+    },
+  ]
+
+  return {
+    getAssignmentCounts: vi.fn().mockResolvedValue(mockCountList),
+  }
+})
+
+import {
+  getWeeksWithAssignments,
+  getCleaningCountMatrix,
+} from '../history-data'
+
+describe('getWeeksWithAssignments', () => {
+  test('週データとアサイン情報を取得する', async () => {
+    const result = await getWeeksWithAssignments()
+
+    expect(result).toHaveLength(2)
+    expect(result[0].id).toBe(1)
+    expect(result[0].assignments).toHaveLength(1)
+    expect(result[0].assignments[0].place.name).toBe('Room')
+    expect(result[0].assignments[0].member.name).toBe('Alice')
+  })
+})
+
+describe('getCleaningCountMatrix', () => {
+  test('掃除回数の集計とマトリックスを作成する', async () => {
+    const result = await getCleaningCountMatrix()
+
+    expect(result.members).toEqual(['Alice', 'Bob'])
+    expect(result.places).toEqual(['Hall', 'Room'])
+    expect(result.matrix).toEqual({
+      Alice: { Hall: 1, Room: 2 },
+      Bob: { Hall: 1 },
+    })
+  })
+
+  test('メンバーと場所が正しくソートされる', async () => {
+    const result = await getCleaningCountMatrix()
+
+    expect(result.members).toEqual(['Alice', 'Bob'])
+    expect(result.places).toEqual(['Hall', 'Room'])
+  })
+
+  test('カウントが存在しない場合は0になる', async () => {
+    const result = await getCleaningCountMatrix()
+
+    expect(result.matrix.Bob.Room).toBeUndefined()
+    expect(result.matrix.Alice.Hall).toBe(1)
+    expect(result.matrix.Alice.Room).toBe(2)
+  })
+})

--- a/src/lib/history-data.ts
+++ b/src/lib/history-data.ts
@@ -1,0 +1,69 @@
+import { prisma } from '@/lib/prisma'
+import { getAssignmentCounts } from '@/lib/history'
+
+export type WeekWithAssignments = {
+  id: number
+  startDate: Date
+  assignments: {
+    id: number
+    placeId: number
+    memberId: number
+    place: {
+      id: number
+      name: string
+    }
+    member: {
+      id: number
+      name: string
+    }
+  }[]
+}
+
+export type CleaningCountMatrix = {
+  members: string[]
+  places: string[]
+  matrix: Record<string, Record<string, number>>
+}
+
+export async function getWeeksWithAssignments(): Promise<
+  WeekWithAssignments[]
+> {
+  const weeks = await prisma.week.findMany({
+    orderBy: { startDate: 'desc' },
+    include: {
+      assignments: {
+        include: { place: true, member: true },
+        orderBy: { placeId: 'asc' },
+      },
+    },
+  })
+
+  return weeks
+}
+
+export async function getCleaningCountMatrix(): Promise<CleaningCountMatrix> {
+  const countList = (await getAssignmentCounts()).sort(
+    (a, b) =>
+      a.memberName.localeCompare(b.memberName) ||
+      a.placeName.localeCompare(b.placeName)
+  )
+
+  const members = Array.from(new Set(countList.map(c => c.memberName))).sort(
+    (a, b) => a.localeCompare(b)
+  )
+  const places = Array.from(new Set(countList.map(c => c.placeName))).sort(
+    (a, b) => a.localeCompare(b)
+  )
+
+  const matrix: Record<string, Record<string, number>> = {}
+  for (const c of countList) {
+    if (!matrix[c.memberName]) matrix[c.memberName] = {}
+    matrix[c.memberName][c.placeName] = c.count
+  }
+
+  return {
+    members,
+    places,
+    matrix,
+  }
+}


### PR DESCRIPTION
## Summary
HistoryContentコンポーネントのビジネスロジックを分離し、テスト可能な構造に改善しました。

- `src/lib/history-data.ts`にビジネスロジックを分離
  - `getWeeksWithAssignments`: 週データと履歴取得
  - `getCleaningCountMatrix`: 掃除回数集計とマトリックス作成
- HistoryContentコンポーネントをUI専用に簡素化
- 型安全性の確保とReactインポート追加

## Test plan
- [x] ビジネスロジックの単体テスト追加 (`src/lib/__tests__/history-data.test.ts`)
- [x] コンポーネントのレンダリングテスト追加 (`src/app/history/__tests__/HistoryContent.test.tsx`)  
- [x] 型チェック (`npm run type-check`) - パス
- [x] lint (`npm run lint`) - パス
- [x] 全テスト (`npm test`) - 90/90テストパス

🤖 Generated with [Claude Code](https://claude.ai/code)