### PR TITLE
Add unit test for RootLayout rendering

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import RootLayout from '../layout'
+
+// Mock CSS imports to avoid PostCSS processing during tests
+vi.mock('../globals.css', () => ({}), { virtual: true })
+vi.mock('@mantine/core/styles.css', () => ({}), { virtual: true })
+
+// Mock Google fonts used in the layout
+vi.mock('next/font/google', () => ({
+  Geist: () => ({ variable: 'geist-sans' }),
+  Geist_Mono: () => ({ variable: 'geist-mono' }),
+}))
+
+describe('RootLayout', () => {
+  test('renders children and basic elements', () => {
+    const html = renderToStaticMarkup(
+      <RootLayout>
+        <div>Child Content</div>
+      </RootLayout>
+    )
+
+    expect(html).toContain('Child Content')
+    expect(html).toContain('<html lang="ja"')
+    expect(html).toContain('geist-sans')
+    expect(html).toContain('geist-mono')
+    expect(html).toContain('antialiased')
+  })
+})

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -3,8 +3,8 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import RootLayout from '../layout'
 
 // Mock CSS imports to avoid PostCSS processing during tests
-vi.mock('../globals.css', () => ({}), { virtual: true })
-vi.mock('@mantine/core/styles.css', () => ({}), { virtual: true })
+vi.mock('../globals.css', () => ({}))
+vi.mock('@mantine/core/styles.css', () => ({}))
 
 // Mock Google fonts used in the layout
 vi.mock('next/font/google', () => ({


### PR DESCRIPTION
## Summary of changes
- add `RootLayout` rendering test

## Related issue numbers
- N/A

## How to test or reproduce
1. `npm install`
2. `npm run lint`
3. `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6868afbc0ffc8327886fc1e10e744819